### PR TITLE
feat(lib-generator): add eperimentalDecorators flag to eslintrc template

### DIFF
--- a/libs/workspace/src/generators/nest-library/files/.eslintrc.json__tmpl__
+++ b/libs/workspace/src/generators/nest-library/files/.eslintrc.json__tmpl__
@@ -4,7 +4,8 @@
 	"overrides": [
 		{
 			"parserOptions": {
-				"emitDecoratorMetadata": true
+				"emitDecoratorMetadata": true,
+				"experimentalDecorators": true
 			},
 			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
 			"rules": {}


### PR DESCRIPTION
without this, the nestjs injection magic won't work as expected. (it'll try to import as type only, and then scream on start)